### PR TITLE
#6 Hide window by using syscall

### DIFF
--- a/chlick_handler.go
+++ b/chlick_handler.go
@@ -3,6 +3,7 @@ package proch
 import (
 	"fmt"
 	"os/exec"
+	"syscall"
 	
 	"golang.org/x/sys/windows/registry"
 
@@ -35,6 +36,7 @@ func (ce *clickEvent) Connect() error {
 
 	// disconnect current wlan
 	netsh_disconnect := exec.Command("C:\\Windows\\system32\\netsh.exe", "wlan", "disconnect")
+	netsh_disconnect.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	out, err := netsh_disconnect.Output()
 	if err != nil {
 		fmt.Printf("Error: faild to disconnect\n\t%s\n", err)
@@ -44,6 +46,7 @@ func (ce *clickEvent) Connect() error {
 
 	// Connect wlan
 	netsh_connect := exec.Command("C:\\Windows\\system32\\netsh.exe", "wlan", "connect", fmt.Sprintf("name=%s", ce.WlanProfile.Ssid))
+	netsh_connect.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	out, err = netsh_connect.Output()
 	if err != nil {
 		fmt.Printf("Error: failed to connect (wlan=%s)\n\t%s\n", ce.WlanProfile.Ssid, err)

--- a/cmd/proch/main.go
+++ b/cmd/proch/main.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 	"github.com/Riki-Okunishi/proch"
 )
 
 func main() {
 	// change encoding from Shift-JIS to UTF-8
-	err := exec.Command("cmd", "/C", "chcp", "65001").Run()
+	chcp := exec.Command("cmd", "/C", "chcp", "65001")
+	chcp.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	err := chcp.Run()
 	if err != nil {
 		fmt.Printf("Error: Failed to change encoding to UTF-8 by executing 'chcp 65001'\n\t%s\n\n", err)
 		os.Exit(1)

--- a/netsh.go
+++ b/netsh.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 
 )
 
 func execNetsh() string {
-	out, err := exec.Command("cmd", "/C", "netsh", "wlan", "show", "profiles").Output()
+	cmd := exec.Command("cmd", "/C", "netsh", "wlan", "show", "profiles")
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	out, err := cmd.Output()
 	if err != nil {
 		fmt.Printf("Error: Failed to execute 'cmd /C netsh wlan show profile'\n\t%s\n\n", err)
 		os.Exit(1)
@@ -19,13 +22,6 @@ func execNetsh() string {
 
 
 func GetWlanProfiles() []string {
-	// change encoding from Shift-JIS to UTF-8
-	err := exec.Command("cmd", "/C", "chcp", "65001").Run()
-	if err != nil {
-		fmt.Printf("Error: Failed to change encoding to UTF-8 by executing 'chcp 65001'\n\t%s\n\n", err)
-		os.Exit(1)
-	}
-
 	// execute command 'netsh wlan show profiles'
 	netsh_profiles := execNetsh()
 
@@ -43,7 +39,9 @@ func GetWlanProfiles() []string {
 }
 
 func GetCurrentSsid() string {
-	out, err := exec.Command("cmd", "/C", "netsh", "wlan", "show", "interface").Output()
+	cmd := exec.Command("cmd", "/C", "netsh", "wlan", "show", "interface")
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	out, err := cmd.Output()
 	if err != nil {
 		fmt.Printf("Error: Failed to execute 'cmd /C netsh wlan show interface'\n\t%s\n\n", err)
 		return ""


### PR DESCRIPTION
## 修正点
+ コマンドプロンプトが一瞬表示される問題を解決
  + `os/exec`で`cmd`を実行する際に，`syscall.SysProcAttr`で`HideWindow: true`を指定することで見えなくなる