### PR TITLE
Fixed some problem

### DIFF
--- a/chlick_handler.go
+++ b/chlick_handler.go
@@ -4,24 +4,25 @@ import (
 	"fmt"
 	"os/exec"
 	"syscall"
-	
+
 	"golang.org/x/sys/windows/registry"
 
 	"github.com/getlantern/systray"
 )
+
 type clickEvent struct {
 	systray.MenuItem
 	WlanProfile wlanProfile
-	eventCh chan string
-	CloseCh chan struct{}
+	eventCh     chan string
+	CloseCh     chan struct{}
 }
 
 func (ce *clickEvent) WaitClick() {
 	for {
 		select {
 		case <-ce.ClickedCh:
-		fmt.Printf("\t%s WaitClick() called!\n", ce.WlanProfile.Ssid)
-		ce.eventCh <- ce.WlanProfile.Ssid
+			fmt.Printf("\t%s WaitClick() called!\n", ce.WlanProfile.Ssid)
+			ce.eventCh <- ce.WlanProfile.Ssid
 		case <-ce.CloseCh:
 			fmt.Printf("Close goroutine %s\n", ce.WlanProfile.Ssid)
 			close(ce.ClickedCh)
@@ -32,7 +33,7 @@ func (ce *clickEvent) WaitClick() {
 }
 
 // Connect will connect the wlan according the information this object has.
-// This function is expected to be called when clickHandler.current is nil. 
+// This function is expected to be called when clickHandler.current is nil.
 func (ce *clickEvent) Connect() error {
 	/* execute netsh and reg*/
 
@@ -66,7 +67,7 @@ func (ce *clickEvent) Connect() error {
 		fmt.Printf("Error: Key.SetDWordValue(...)\n\t%s\n\n", err)
 		return err
 	}
-	
+
 	if dword == 0 {
 		return nil
 	}
@@ -102,12 +103,11 @@ func (ce *clickEvent) Disconnect() error {
 	return nil
 }
 
-
-
 type clickHandler struct {
-	eventCh chan string
-	current *clickEvent
+	eventCh   chan string
+	current   *clickEvent
 	eventList map[string]*clickEvent
+	refresh   *systray.MenuItem
 }
 
 func NewClickHandler() *clickHandler {
@@ -121,19 +121,9 @@ func (ch *clickHandler) AddEvent(wp wlanProfile) {
 	ch.eventList[wp.Ssid] = ce
 }
 
-
 func (ch *clickHandler) HandleClick() {
 	//current network must be checked
-	cssid := GetCurrentSsid()
-	fmt.Printf("Current SSID: '%s'\n", cssid)
-	if ec, ok := ch.eventList[cssid]; ok {
-		ec.Check()
-		setTooltip(ec.WlanProfile.ProxyEnable)
-		ch.current = ec
-	} else {
-		setTooltip(false)
-		ch.current = nil
-	}
+	ch.refreshCurrentSsid()
 
 	// exec goroutine each Buttom
 	for _, e := range ch.eventList {
@@ -191,7 +181,7 @@ func (ch *clickHandler) HandleClick() {
 				setTooltip(ce.WlanProfile.ProxyEnable)
 				ch.current = ce
 			} else {
-				
+
 				// Dissconnect current SSID
 				if ch.current == nil {
 					fmt.Printf("Error: expected ch.current is not nil when checked menu item was clicked\n")
@@ -207,6 +197,9 @@ func (ch *clickHandler) HandleClick() {
 				setTooltip(false)
 				ch.current = nil
 			}
+		case <-ch.refresh.ClickedCh:
+			fmt.Printf("Clicked Refresh\n")
+			ch.refreshCurrentSsid()
 		}
 	}
 }
@@ -227,4 +220,20 @@ func setTooltip(proxyEnable bool) {
 		str = "Disable"
 	}
 	systray.SetTooltip(fmt.Sprintf("Proxy Changer\nProxy: %s", str))
+}
+
+func (ch *clickHandler) refreshCurrentSsid() {
+	cssid := GetCurrentSsid()
+	fmt.Printf("Current SSID: '%s'\n", cssid)
+	for _, n := range ch.eventList {
+		n.Uncheck()
+	}
+	if ec, ok := ch.eventList[cssid]; ok {
+		ec.Check()
+		setTooltip(ec.WlanProfile.ProxyEnable)
+		ch.current = ec
+	} else {
+		setTooltip(false)
+		ch.current = nil
+	}
 }

--- a/chlick_handler.go
+++ b/chlick_handler.go
@@ -148,12 +148,27 @@ func (ch *clickHandler) HandleClick() {
 		case ssid := <-ch.eventCh:
 			fmt.Printf("\tclicked %s!\n", ssid)
 			// check clicked SSID
-			ec, ok := ch.eventList[ssid]
+			ce, ok := ch.eventList[ssid]
 			if !ok {
-				fmt.Printf("Error: not found such event represented as '%s'", ssid)
+				fmt.Printf("Error: not found such event represented as '%s'\n", ssid)
 				continue
 			}
-			if !ec.Checked() {
+
+			// Check this ssid exists around here
+			net := GetWlanNetworks()
+			find := false
+			for _, s := range net {
+				if s == ce.WlanProfile.Ssid {
+					find = true
+					break
+				}
+			}
+			if !find {
+				fmt.Printf("error: not found the network '%s' around here\n", ce.WlanProfile.Ssid)
+				continue
+			}
+
+			if !ce.Checked() {
 
 				//disconnect from previous network
 				if ch.current != nil {
@@ -168,13 +183,13 @@ func (ch *clickHandler) HandleClick() {
 				}
 
 				// try connect
-				if err := ec.Connect(); err != nil {
+				if err := ce.Connect(); err != nil {
 					fmt.Printf("Error: failed to connect\n\t%s\n", err)
 					continue
 				}
-				ec.Check()
-				setTooltip(ec.WlanProfile.ProxyEnable)
-				ch.current = ec
+				ce.Check()
+				setTooltip(ce.WlanProfile.ProxyEnable)
+				ch.current = ce
 			} else {
 				
 				// Dissconnect current SSID

--- a/netsh.go
+++ b/netsh.go
@@ -54,3 +54,24 @@ func GetCurrentSsid() string {
 	
 	return cssid
 }
+
+func GetWlanNetworks() []string {
+	tmp := []string{}
+	cmd := exec.Command("cmd", "/C", "netsh", "wlan", "show", "networks")
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Printf("Error: falied to execute 'cmd /C netsh wlan show networks'\n\t%s\n", err)
+		return tmp
+	}
+	tmp = strings.Split(string(out), " : ")
+	tmp = tmp[2:]
+	net := []string{}
+	for i := 0; i < len(tmp); i+=4 {
+		splts := strings.Split(tmp[i], "\n")
+		trimed := strings.Trim(splts[0], " ")
+		net = append(net, trimed[:len(trimed)-1])
+	}
+
+	return net
+}

--- a/netsh_test.go
+++ b/netsh_test.go
@@ -1,0 +1,13 @@
+package proch
+
+import (
+	"testing"
+)
+
+func TestGetWlanNetworks(t *testing.T){
+	net := GetWlanNetworks()
+	for i, ssid := range net {
+		t.Logf("SSID %d : '%s'", i, ssid)
+	}
+
+}

--- a/proch.go
+++ b/proch.go
@@ -113,10 +113,13 @@ func (pc *proxyChanger) onReady() {
 	// clickHandler goroutine
 	go ch.HandleClick() // v2: AddMenu after goroutine
 	
+	// Refresh Menu
+	systray.AddSeparator()
+	ch.refresh = systray.AddMenuItem("Refresh", "Refresh the SSID list")
 
 	// Quit Menu	
 	systray.AddSeparator()
-	mQuitOrig := systray.AddMenuItem("終了", "Quit the whole app")
+	mQuitOrig := systray.AddMenuItem("Quit", "Quit the whole app")
 	go func() {
 		<-mQuitOrig.ClickedCh
 		fmt.Println("Requesting quit")

--- a/wlan_profile_test.go
+++ b/wlan_profile_test.go
@@ -1,9 +1,7 @@
-package proch_test
+package proch
 
 import (
 	"testing"
-
-	"github.com/Riki-Okunishi/proch"
 )
 
 var (
@@ -11,7 +9,7 @@ var (
 )
 
 func TestImportJson(t *testing.T) {
-	wp, err := proch.ImportJson(filepath)
+	wp, err := ImportJson(filepath)
 	if err != nil {
 		t.Errorf("Failed to import JSON file '%s'\n", filepath)
 	}


### PR DESCRIPTION
## 変更点
+ チェック済み(=接続中)のSSIDを選択した場合の挙動を変更
  + 無反応ではなく，切断するように変更
+ 周辺に存在しないSSIDを選択した場合の挙動を変更
  + 繋がらないネットワークに接続してしまっていたのを，切り替えない(=今の無線LANから切断しない)ように変更
+ Refreshボタンの追加
  + 押下すると現在接続しているSSIDにチェックが更新される
  + どこにも接続していない場合はチェックが外れる
  + 移動したり手動で切り替えたりして噛み合わなくなった時に使用