### PR TITLE
#21 Add test code

### DIFF
--- a/json_loader.go
+++ b/json_loader.go
@@ -17,7 +17,7 @@ type wlanProfile struct {
 }
 
 type jsonLoadable interface {
-	Load(string) ([]wlanProfile, error)
+	Load(filepath string) ([]wlanProfile, error)
 }
 
 type jsonLoader struct {

--- a/json_loader_mock_test.go
+++ b/json_loader_mock_test.go
@@ -1,0 +1,19 @@
+package proch
+
+import (
+	"fmt"
+)
+
+type jsonLoaderMock struct {
+	filepath string
+	profiles []wlanProfile
+}
+
+var _ jsonLoadable = &jsonLoaderMock{}
+
+func (jlm *jsonLoaderMock) Load(filepath string) ([]wlanProfile, error) {
+	if filepath != jlm.filepath {
+		return []wlanProfile{}, fmt.Errorf("error [jsonLoaderMock]: cannot load the json file")
+	}
+	return jlm.profiles, nil
+}

--- a/netsh_mock_test.go
+++ b/netsh_mock_test.go
@@ -1,0 +1,41 @@
+package proch
+
+import (
+	"fmt"
+)
+
+type netshRunnerMock struct {
+	connectSsid string
+	disconnect bool
+	profiles []string
+	networks []string
+	cssid string
+}
+
+var _ netshRunnable = &netshRunnerMock{}
+
+func (nrm *netshRunnerMock) Connect(ssid string) error {
+	if ssid != nrm.connectSsid {
+		return fmt.Errorf("error [netshRunnerMock]: cannot connect")
+	}
+	return nil
+}
+
+func (nrm *netshRunnerMock) Disconnect() error {
+	if !nrm.disconnect {
+		return fmt.Errorf("error [netshRunnerMock]: cannot disconnect")
+	}
+	return nil
+}
+
+func (nrm *netshRunnerMock) ShowProfiles() []string {
+	return nrm.profiles
+}
+
+func (nrm *netshRunnerMock) ShowNetworks() []string {
+	return nrm.networks
+}
+
+func (nrm *netshRunnerMock) GetCurrentSsid() string {
+	return nrm.cssid
+}

--- a/proch_test.go
+++ b/proch_test.go
@@ -1,0 +1,73 @@
+package proch
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+	"syscall"
+	"runtime"
+	"testing"
+
+)
+
+
+func TestMain(m *testing.M) {
+	switch runtime.GOOS {
+	case "windows":
+		fmt.Printf("running on Windows. continue executing proch.\n")
+	default:
+		fmt.Printf("running on OS not supported. exit proch.")
+		os.Exit(1)
+	}
+
+	// change encoding from Shift-JIS to UTF-8
+	chcp := exec.Command("cmd", "/C", "chcp", "65001")
+	chcp.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	err := chcp.Run()
+	if err != nil {
+		fmt.Printf("Error: Failed to change encoding to UTF-8 by executing 'chcp 65001'\n\t%s\n\n", err)
+		os.Exit(1)
+	}
+
+	m.Run()
+}
+
+func TestProchRun(t *testing.T) {
+
+	nrm := &netshRunnerMock{connectSsid: "SSID2", disconnect: true, profiles: []string{"SSID1", "SSID2"}, networks: []string{"SSID1", "SSID2"}, cssid: "SSID1"}
+	rem := &registryEditorMock{filepath: "./test/test.json", proxyEnable: false, proxyServer: "proxy.com:80", proxyOverride: "192.168.0.*;<local>"}
+	profiles := []wlanProfile{
+		{
+			Ssid: "SSID1",
+			ProxyEnable: true,
+			ProxyServer: "proxy.com:80",
+			ProxyOverride: "192.168.0.*;<local>",
+		},
+		{
+			Ssid: "SSID2",
+			ProxyEnable: false,
+		},
+	}
+	jlm := &jsonLoaderMock{filepath: "./test/test.json", profiles: profiles}
+
+	pc := New(nrm, rem, jlm)
+
+	go func() {
+		time.Sleep(2*time.Second) // Wait proch
+
+		pc.ssidCh <- "SSID2"
+
+		time.Sleep(1*time.Second) // Wait proch
+
+		if pc.current.ssid != "SSID2" {
+			t.Errorf("clicked \"SSID2\": expected=SSID2, result=%s", pc.current.ssid)
+		}
+
+		t.Logf("finish proch")
+		pc.quit.ClickedCh <- struct{}{}
+	}()
+
+	pc.Run()
+
+}

--- a/registry.go
+++ b/registry.go
@@ -13,7 +13,7 @@ const (
 
 type registryEditable interface {
 	GetSettingJsonPath() string
-	EditProxySettings(bool, string, string) error
+	EditProxySettings(proxyEnable bool, proxyServer string, proxyOverride string) error
 }
 
 type registryEditor struct {

--- a/registry_mock_test.go
+++ b/registry_mock_test.go
@@ -1,0 +1,27 @@
+package proch
+
+import (
+	"fmt"
+)
+
+type registryEditorMock struct {
+	filepath string
+	proxyEnable bool
+	proxyServer string
+	proxyOverride string
+}
+
+var _ registryEditable = &registryEditorMock{}
+
+func (rem *registryEditorMock) GetSettingJsonPath() string {
+	return rem.filepath
+}
+
+func (rem *registryEditorMock) EditProxySettings(proxyEnable bool, proxyServer string, proxyOverride string) error {
+	if proxyEnable {
+		if proxyServer != rem.proxyServer || proxyOverride != rem.proxyOverride {
+			return fmt.Errorf("error [registryEditorMock]: cannot edit registry")
+		}
+	}
+	return nil
+}

--- a/ssid_menuitem.go
+++ b/ssid_menuitem.go
@@ -8,26 +8,26 @@ import (
 )
 
 type ssidMenuItem struct {
-	systray.MenuItem
+	*systray.MenuItem
 	ssid string
-	proxyEanble bool
+	proxyEnable bool
 	proxyServer string
 	proxyOverride string
 	ssidCh chan string
 	closeCh chan struct{}
 }
 
-func newSsidMenuItem(ssidCh chan string, ssid string, proxyEnable bool, proxyServer string, proxyOverride string) *ssidMenuItem {
-	mi := systray.AddMenuItemCheckbox(ssid, fmt.Sprintf("Connect to %s", ssid), false)
-	smi := &ssidMenuItem{MenuItem: *mi, ssid: ssid, proxyEanble: proxyEnable, proxyServer: proxyServer, proxyOverride: proxyOverride, ssidCh: ssidCh, closeCh: make(chan struct{})}
+func newSsidMenuItem(mi *systray.MenuItem, ssidCh chan string, ssid string, proxyEnable bool, proxyServer string, proxyOverride string) *ssidMenuItem {
+	// TODO: Add validation for mi, ssid, proxyServer and proxyOverride (when proxyEnable == true)
+	smi := &ssidMenuItem{MenuItem: mi, ssid: ssid, proxyEnable: proxyEnable, proxyServer: proxyServer, proxyOverride: proxyOverride, ssidCh: ssidCh, closeCh: make(chan struct{})}
 	return smi
 }
 
-func (smi *ssidMenuItem) WaitClick() {
+func (smi *ssidMenuItem) waitClick() {
 	for {
 	select {
 	case <-smi.ClickedCh:
-		fmt.Printf("%s WaitClick() called.\n", smi.ssid)
+		fmt.Printf("%s waitClick() called.\n", smi.ssid)
 		smi.ssidCh <- smi.ssid
 	case <-smi.closeCh:
 		fmt.Printf("Close goroutine %s\n", smi.ssid)

--- a/ssid_menuitem_test.go
+++ b/ssid_menuitem_test.go
@@ -1,0 +1,194 @@
+package proch
+
+import (
+	"testing"
+
+	"github.com/getlantern/systray"
+)
+
+type testCase struct {
+	mi *systray.MenuItem
+	ssidCh chan string
+	ssid string
+	proxyEnable bool
+	proxyServer string
+	proxyOverride string
+	expected interface{}
+}
+
+func TestNewSsidMenuItemWithSsid(t *testing.T) {
+	
+	mi := &systray.MenuItem{}
+	testCh := make(chan string, 1)
+
+	ssidTest := []testCase{
+		{
+			mi: mi,
+			ssidCh: testCh,
+			ssid: "SSID1",
+			proxyEnable: true,
+			proxyServer: "proxy.com:80",
+			proxyOverride: "192.168.0.*;<local>",
+			expected: "SSID1",
+		},
+	}
+
+
+	for i, tc := range ssidTest {
+		smi := newSsidMenuItem(tc.mi, tc.ssidCh, tc.ssid, tc.proxyEnable, tc.proxyServer, tc.proxyOverride)
+
+		if smi.ssid != tc.expected {
+			t.Errorf("in ssidTest[%d]: expected=%s but result=%s", i, tc.expected, smi.ssid)
+		}
+	}
+}
+
+func TestNewSsidMenuItemWithProxyEnable(t *testing.T) {
+	
+	testCh := make(chan string, 1)
+
+	proxyEnableTest := []testCase{
+		{
+			mi: &systray.MenuItem{},
+			ssidCh: testCh,
+			ssid: "SSID1",
+			proxyEnable: true,
+			proxyServer: "proxy.com:80",
+			proxyOverride: "192.168.0.*;<local>",
+			expected: true,
+		},
+		{
+			mi: &systray.MenuItem{},
+			ssidCh: testCh,
+			ssid: "SSID2",
+			proxyEnable: false,
+			proxyServer: "",
+			proxyOverride: "",
+			expected: false,
+		},
+	}
+
+
+	for i, tc := range proxyEnableTest {
+		smi := newSsidMenuItem(tc.mi, testCh, tc.ssid, tc.proxyEnable, tc.proxyServer, tc.proxyOverride)
+
+		if smi.proxyEnable != tc.expected {
+			t.Errorf("in ssidTest[%d]: expected=%v but result=%v", i, tc.expected, smi.proxyEnable)
+		}
+	}
+}
+
+func TestNewSsidMenuItemWithProxyServer(t *testing.T) {
+	
+	testCh := make(chan string, 1)
+
+	proxyServerTest := []testCase{
+		{
+			mi: &systray.MenuItem{},
+			ssidCh: testCh,
+			ssid: "SSID1",
+			proxyEnable: true,
+			proxyServer: "proxy.com:80",
+			proxyOverride: "192.168.0.*;<local>",
+			expected: "proxy.com:80",
+		},
+		{
+			mi: &systray.MenuItem{},
+			ssidCh: testCh,
+			ssid: "SSID2",
+			proxyEnable: false,
+			proxyServer: "",
+			proxyOverride: "",
+			expected: "",
+		},
+		{
+			mi: &systray.MenuItem{},
+			ssidCh: testCh,
+			ssid: "SSID3",
+			proxyEnable: true,
+			proxyServer: "proxy.com",
+			proxyOverride: "192.168.0.*;<local>",
+			expected: nil,
+		},
+		{
+			mi: &systray.MenuItem{},
+			ssidCh: testCh,
+			ssid: "SSID4",
+			proxyEnable: true,
+			proxyServer: ":80",
+			proxyOverride: "192.168.0.*;<local>",
+			expected: nil,
+		},
+	}
+
+
+	for i, tc := range proxyServerTest {
+		smi := newSsidMenuItem(tc.mi, testCh, tc.ssid, tc.proxyEnable, tc.proxyServer, tc.proxyOverride)
+
+		if smi.proxyServer != tc.expected {
+			t.Errorf("in ssidTest[%d]: expected=%v but result=%v", i, tc.expected, smi.proxyServer)
+		}
+	}
+}
+
+func TestNewSsidMenuItemWithProxyOverride(t *testing.T) {
+	
+	testCh := make(chan string, 1)
+
+	proxyOverrideTest := []testCase{
+		{
+			mi: &systray.MenuItem{},
+			ssidCh: testCh,
+			ssid: "SSID1",
+			proxyEnable: true,
+			proxyServer: "proxy.com:80",
+			proxyOverride: "192.168.0.*;<local>",
+			expected: "192.168.0.*;<local>",
+		},
+		{
+			mi: &systray.MenuItem{},
+			ssidCh: testCh,
+			ssid: "SSID2",
+			proxyEnable: true,
+			proxyServer: "proxy.com:80",
+			proxyOverride: "192.168.0.1",
+			expected: "192.168.0.1",
+		},
+		{
+			mi: &systray.MenuItem{},
+			ssidCh: testCh,
+			ssid: "SSID3",
+			proxyEnable: true,
+			proxyServer: "proxy.com:80",
+			proxyOverride: "<local>",
+			expected: "<local>",
+		},
+		{
+			mi: &systray.MenuItem{},
+			ssidCh: testCh,
+			ssid: "SSID4",
+			proxyEnable: true,
+			proxyServer: "proxy.com:80",
+			proxyOverride: "192.168.0.256;<local>",
+			expected: nil,
+		},
+		{
+			mi: &systray.MenuItem{},
+			ssidCh: testCh,
+			ssid: "SSID5",
+			proxyEnable: true,
+			proxyServer: "proxy.com:80",
+			proxyOverride: "192.168.*;<local>",
+			expected: nil,
+		},
+	}
+
+
+	for i, tc := range proxyOverrideTest {
+		smi := newSsidMenuItem(tc.mi, testCh, tc.ssid, tc.proxyEnable, tc.proxyServer, tc.proxyOverride)
+
+		if smi.proxyOverride != tc.expected {
+			t.Errorf("in ssidTest[%d]: expected=%v but result=%v", i, tc.expected, smi.proxyOverride)
+		}
+	}
+}

--- a/test/test.json
+++ b/test/test.json
@@ -2,13 +2,13 @@
   "version": 1.0,
   "profiles": [
     {
-      "ssid": "KE101-Proxy(2.4GHz)",
+      "ssid": "SSID1",
       "proxyEnable": true,
-      "proxyServer": "proxy.doshisha.ac.jp:8080",
-      "proxyOverride": "172.20.69.*;<local>"
+      "proxyServer": "proxy.com:80",
+      "proxyOverride": "192.168.0.*;<local>"
     },
     {
-      "ssid": "KE101-Core(2.4GHz)",
+      "ssid": "SSID2",
       "proxyEnable": false
     }
   ]


### PR DESCRIPTION
#21 に沿ってテストコードを追加

## 追加
+ Mockコード
  + `netshRunnerMock`
  + `registryEditorMock`
  + `jsonLoaderMock`
+ `proxyChanger`のテストコード
  + prochの持つchannelに直接送信して操作
  + 上記3つのMockを使う
+ `ssidMenuItem`のテストコード
  + 明示的なテストケースを追加

## 課題
+ 一部テスト未対応
  + `ssidMenuItem`
    + 初期化引数が不適切な場合
    + プロキシ設定のサーバアドレスやオーバーライドが不正の場合
+ Mockの設計
  + ある程度オリジナルと同様のエラーハンドリングが必要？
  + それともただ規定の値を返すだけのハリボテとする？
